### PR TITLE
fix: add can reveal method

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,8 @@
 name: publish
 
 on:
-  push:
-    branches:
-      - 'main'
+  release:
+    types: [created]
 
 jobs:
   publish:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rns-sdk",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "description": "RNS SDK",
   "main": "dist/bundle.js",
   "types": "dist/index.d.ts",

--- a/src/RSKRegistrar.ts
+++ b/src/RSKRegistrar.ts
@@ -52,7 +52,7 @@ export class RSKRegistrar {
     }
 
     async canReveal (hash: string): Promise<{ canReveal: ()=> Promise<boolean> }> {
-        return {  canReveal: () => this.fifsAddrRegistrar.canReveal(hash) }
+      return { canReveal: () => this.fifsAddrRegistrar.canReveal(hash) }
     }
 
     async register (label: string, owner: string, secret: string, duration: BigNumber, amount: BigNumber, addr?: string): Promise<ContractTransaction> {

--- a/src/RSKRegistrar.ts
+++ b/src/RSKRegistrar.ts
@@ -43,12 +43,16 @@ export class RSKRegistrar {
       return this.fifsAddrRegistrar.price(label, constants.Zero, duration)
     }
 
-    async commitToRegister (label: string, owner: string): Promise<{ secret: string, makeCommitmentTransaction: ContractTransaction, canReveal: ()=> Promise<boolean> }> {
+    async commitToRegister (label: string, owner: string): Promise<{ secret: string, makeCommitmentTransaction: ContractTransaction, canReveal: ()=> Promise<boolean>, hash: string }> {
       const secret = generateSecret()
       const hash = await this.fifsAddrRegistrar.makeCommitment(hashLabel(label), owner, secret)
       const makeCommitmentTransaction = await this.fifsAddrRegistrar.commit(hash)
 
-      return { secret, makeCommitmentTransaction, canReveal: () => this.fifsAddrRegistrar.canReveal(hash) }
+      return { secret, makeCommitmentTransaction, canReveal: () => this.fifsAddrRegistrar.canReveal(hash), hash }
+    }
+
+    async canReveal (hash: string): Promise<{ canReveal: ()=> Promise<boolean> }> {
+        return {  canReveal: () => this.fifsAddrRegistrar.canReveal(hash) }
     }
 
     async register (label: string, owner: string, secret: string, duration: BigNumber, amount: BigNumber, addr?: string): Promise<ContractTransaction> {

--- a/src/RSKRegistrar.ts
+++ b/src/RSKRegistrar.ts
@@ -51,8 +51,8 @@ export class RSKRegistrar {
       return { secret, makeCommitmentTransaction, canReveal: () => this.fifsAddrRegistrar.canReveal(hash), hash }
     }
 
-    async canReveal (hash: string): Promise<{ canReveal: ()=> Promise<boolean> }> {
-      return { canReveal: () => this.fifsAddrRegistrar.canReveal(hash) }
+    async canReveal (hash: string): Promise< ()=> Promise<boolean> > {
+      return () => this.fifsAddrRegistrar.canReveal(hash)
     }
 
     async register (label: string, owner: string, secret: string, duration: BigNumber, amount: BigNumber, addr?: string): Promise<ContractTransaction> {

--- a/test/rskRegistrar.test.ts
+++ b/test/rskRegistrar.test.ts
@@ -42,19 +42,22 @@ describe('rsk registrar', () => {
     const rskRegistrar = new RSKRegistrar(rskOwnerContract.address, fifsAddrRegistrarContract.address, rifTokenContract.address, testAccount)
     const owner = await testAccount.getAddress()
 
-    const { makeCommitmentTransaction, secret, canReveal } = await rskRegistrar.commitToRegister(label, owner)
+    const { makeCommitmentTransaction, secret, canReveal, hash } = await rskRegistrar.commitToRegister(label, owner)
+    const myCanReveal = await rskRegistrar.canReveal(hash)
     const makeCommitmentTransactionReceipt = await makeCommitmentTransaction.wait()
 
     expect(makeCommitmentTransactionReceipt.status).toEqual(1)
 
-    const hash = await fifsAddrRegistrarContract.makeCommitment(hashLabel(label), owner, secret)
-    expect(await fifsAddrRegistrarContract.canReveal(hash)).toEqual(false)
+    const hash2 = await fifsAddrRegistrarContract.makeCommitment(hashLabel(label), owner, secret)
+    expect(await fifsAddrRegistrarContract.canReveal(hash2)).toEqual(false)
     expect(await canReveal()).toEqual(false)
+    expect(await myCanReveal()).toEqual(false)
 
     await provider.send('evm_increaseTime', [1001])
     await provider.send('evm_mine', [])
-    expect(await fifsAddrRegistrarContract.canReveal(hash)).toEqual(true)
+    expect(await fifsAddrRegistrarContract.canReveal(hash2)).toEqual(true)
     expect(await canReveal()).toEqual(true)
+    expect(await myCanReveal()).toEqual(true)
   })
   test('register', async () => {
     const label = 'domain-to-test-registration'

--- a/test/rskRegistrar.test.ts
+++ b/test/rskRegistrar.test.ts
@@ -48,14 +48,14 @@ describe('rsk registrar', () => {
 
     expect(makeCommitmentTransactionReceipt.status).toEqual(1)
 
-    const hash2 = await fifsAddrRegistrarContract.makeCommitment(hashLabel(label), owner, secret)
-    expect(await fifsAddrRegistrarContract.canReveal(hash2)).toEqual(false)
+    const makeCommitmentHash = await fifsAddrRegistrarContract.makeCommitment(hashLabel(label), owner, secret)
+    expect(await fifsAddrRegistrarContract.canReveal(makeCommitmentHash)).toEqual(false)
     expect(await canReveal()).toEqual(false)
     expect(await myCanReveal()).toEqual(false)
 
     await provider.send('evm_increaseTime', [1001])
     await provider.send('evm_mine', [])
-    expect(await fifsAddrRegistrarContract.canReveal(hash2)).toEqual(true)
+    expect(await fifsAddrRegistrarContract.canReveal(makeCommitmentHash)).toEqual(true)
     expect(await canReveal()).toEqual(true)
     expect(await myCanReveal()).toEqual(true)
   })


### PR DESCRIPTION
In order to implement https://rsklabs.atlassian.net/browse/US-1001 we need to store the hash in the local store and be able to get the canReveal function on demand since it not posible to store a promise in the local storage. We need to store the hash