### PR TITLE
docs: remove partner configuration from argument for commit and register

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,8 @@ const duration = BigNumber.from('1')
 const ownerAddress = '0x...' //address of the owner of the domain
 
 const price = await partnerRegistrar.price(label, duration)
-const partnerConfigurationAddress = '0x...' //address of the partner configuration contract
 
-await partnerRegistrar.commitAndRegister(label, ownerAddress, duration, price, partnerConfigurationAddress)
+await partnerRegistrar.commitAndRegister(label, ownerAddress, duration, price)
 ```
 
 - Renew the domain


### PR DESCRIPTION
This removes the partner configuration argument for the `commitAndRegister` method on the Partner Registrar class since it is no longer required.