### PR TITLE
feat: enable default partner address

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,9 @@ import { Signer } from 'ethers'
 import { PartnerRegistrar } from '@rsksmart/rns-sdk'
 
 let signer: Signer
-const partnerRegistrar = new PartnerRegistrar(partnerAccountAddress, partnerRegistrarContractAddress, partnerRenewerContractAddress, rskOwnerContractAddress, rifTokenContractAddress, signer);
+const partnerRegistrar = new PartnerRegistrar( partnerRegistrarContractAddress, partnerRenewerContractAddress, rskOwnerContractAddress, rifTokenContractAddress, signer, partnerAccountAddress);
 ```
+> NB: The partnerAccountAddress is an optional param. If not included, the default value will be used
 
 - Query price and availability
 

--- a/README.md
+++ b/README.md
@@ -135,9 +135,24 @@ import { Signer } from 'ethers'
 import { PartnerRegistrar } from '@rsksmart/rns-sdk'
 
 let signer: Signer
-const partnerRegistrar = new PartnerRegistrar( partnerRegistrarContractAddress, partnerRenewerContractAddress, rskOwnerContractAddress, rifTokenContractAddress, signer, partnerAccountAddress);
+
+const networkAddresses = {
+  rskOwnerAddress: '0x0000000000000000000000000000000000000000',
+  rifTokenAddress: '0x0000000000000000000000000000000000000000',
+  partnerRegistrarAddress: '0x0000000000000000000000000000000000000000',
+  partnerRenewerAddress: '0x0000000000000000000000000000000000000000',
+  partnerAddress: '0x0000000000000000000000000000000000000000'
+}
+
+const partnerRegistrar = new PartnerRegistrar(signer, 'localhost', networkAddresses);
 ```
-> NB: The partnerAccountAddress is an optional param. If not included, the default value will be used
+**Note:**
+
+The `network` param is mandatory value, and it only valid values are `'mainnet'`, `'testnet'` or `'localhost'`.
+
+Param `networkAddresses` is mandatory for `network='localhost'`.
+For `'mainnnet'` and `'testnet'` will be optional and can be passed only in case of needing to modify one of the default
+addresses for the given network.
 
 - Query price and availability
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ The `network` param is mandatory value, and it only valid values are `'mainnet'`
 
 Param `networkAddresses` is mandatory for `network='localhost'`.
 For `'mainnnet'` and `'testnet'` will be optional and can be passed only in case of needing to modify one of the default
-addresses for the given network.
+addresses for the given network, otherwise, default addresses will be used.
 
 - Query price and availability
 

--- a/src/PartnerRegistrar.ts
+++ b/src/PartnerRegistrar.ts
@@ -112,21 +112,11 @@ export class PartnerRegistrar {
       throw new Error('Network addresses must be provided for localhost network')
     } else if (network !== 'localhost' && networkAddresses) {
 
-      if ( networkAddresses?.rskOwnerAddress ) {
-        this.networkAddresses.rskOwnerAddress = networkAddresses.rskOwnerAddress;
-      }
-      if ( networkAddresses?.partnerRegistrarAddress ) { 
-        this.networkAddresses.partnerRegistrarAddress = networkAddresses.partnerRegistrarAddress;
-      }
-      if (networkAddresses?.partnerRenewerAddress ) {
-        this.networkAddresses.partnerRenewerAddress = networkAddresses.partnerRenewerAddress;
-      }
-      if ( networkAddresses?.rifTokenAddress ) {
-        this.networkAddresses.rifTokenAddress = networkAddresses.rifTokenAddress;
-      }
-      if ( networkAddresses?.partnerAddress ) {
-        this.networkAddresses.partnerAddress = networkAddresses.partnerAddress;
-      }
+      this.networkAddresses.rskOwnerAddress = networkAddresses?.rskOwnerAddress ? networkAddresses.rskOwnerAddress : this.getDefaultNetworkAddresses(network).rskOwnerAddress
+      this.networkAddresses.partnerRegistrarAddress = networkAddresses?.partnerRegistrarAddress ? networkAddresses.partnerRegistrarAddress : this.getDefaultNetworkAddresses(network).partnerRegistrarAddress
+      this.networkAddresses.partnerRenewerAddress = networkAddresses?.partnerRenewerAddress ? networkAddresses.partnerRenewerAddress : this.getDefaultNetworkAddresses(network).partnerRenewerAddress 
+      this.networkAddresses.rifTokenAddress = networkAddresses?.rifTokenAddress ? networkAddresses.rifTokenAddress : this.getDefaultNetworkAddresses(network).rifTokenAddress
+      this.networkAddresses.partnerAddress = networkAddresses?.partnerAddress ? networkAddresses.partnerAddress : this.getDefaultNetworkAddresses(network).partnerAddress
 
     }
 

--- a/src/PartnerRegistrar.ts
+++ b/src/PartnerRegistrar.ts
@@ -39,7 +39,8 @@ interface OperationResult<T> {
 type Network = 'mainnet' | 'testnet' | 'localhost'
 
 interface NetworkAddresses {
-  partnerAddress?: string | null;
+  // [key: string]: string | undefined;
+  partnerAddress?: string;
   partnerRegistrarAddress?: string;
   partnerRenewerAddress?: string;
   rifTokenAddress?: string;
@@ -106,6 +107,23 @@ export class PartnerRegistrar {
 
     if (network === 'localhost' && !networkAddresses) {
       throw new Error('Network addresses must be provided for localhost network')
+    } else if (network === 'localhost' && networkAddresses) {
+      // validates to make sure all the keys are present and their values are not null
+      if (!('partnerAddress' in networkAddresses || networkAddresses.partnerAddress === null)) {
+        throw new Error('partnerAddress address must be provided for localhost network & it\'s value cannot be null')
+      }
+      if (!('partnerRegistrarAddress' in networkAddresses || networkAddresses.partnerRegistrarAddress === null)) {
+        throw new Error('partnerRegistrarAddress address must be provided for localhost network & it\'s value cannot be null')
+      }
+      if (!('partnerRenewerAddress' in networkAddresses || networkAddresses.partnerRenewerAddress === null)) {
+        throw new Error('partnerRenewerAddress address must be provided for localhost network & it\'s value cannot be null')
+      }
+      if (!('rifTokenAddress' in networkAddresses || networkAddresses.rifTokenAddress === null)) {
+        throw new Error('rifTokenAddress address must be provided for localhost network & it\'s value cannot be null')
+      }
+      if (!('rskOwnerAddress' in networkAddresses || networkAddresses.rskOwnerAddress === null)) {
+        throw new Error('rskOwnerAddress address must be provided for localhost network & it\'s value cannot be null')
+      }
     } else if (network !== 'localhost' && networkAddresses) {
       this.networkAddresses.rskOwnerAddress = networkAddresses?.rskOwnerAddress ? networkAddresses.rskOwnerAddress : this.getDefaultNetworkAddresses(network).rskOwnerAddress
       this.networkAddresses.partnerRegistrarAddress = networkAddresses?.partnerRegistrarAddress ? networkAddresses.partnerRegistrarAddress : this.getDefaultNetworkAddresses(network).partnerRegistrarAddress

--- a/src/PartnerRegistrar.ts
+++ b/src/PartnerRegistrar.ts
@@ -44,7 +44,7 @@ interface NetworkAddresses {
   partnerRenewerAddress?: string;
   rifTokenAddress?: string;
   rskOwnerAddress?: string;
-} 
+}
 
 // TODO: Replace placeholder address with the correct addresses
 const mainnetAddresses: NetworkAddresses = {
@@ -94,48 +94,40 @@ export class PartnerRegistrar {
   rifToken: Contract
   signer: Signer
   partnerAddress: string
-
   networkAddresses: NetworkAddresses
-
-  
-
 
   constructor (
     signer: Signer,
     network: Network,
-    networkAddresses?: NetworkAddresses,
+    networkAddresses?: NetworkAddresses
   ) {
     this.signer = signer
-    this.networkAddresses = networkAddresses ?? this.getDefaultNetworkAddresses(network);
+    this.networkAddresses = networkAddresses ?? this.getDefaultNetworkAddresses(network)
 
     if (network === 'localhost' && !networkAddresses) {
       throw new Error('Network addresses must be provided for localhost network')
     } else if (network !== 'localhost' && networkAddresses) {
-
       this.networkAddresses.rskOwnerAddress = networkAddresses?.rskOwnerAddress ? networkAddresses.rskOwnerAddress : this.getDefaultNetworkAddresses(network).rskOwnerAddress
       this.networkAddresses.partnerRegistrarAddress = networkAddresses?.partnerRegistrarAddress ? networkAddresses.partnerRegistrarAddress : this.getDefaultNetworkAddresses(network).partnerRegistrarAddress
-      this.networkAddresses.partnerRenewerAddress = networkAddresses?.partnerRenewerAddress ? networkAddresses.partnerRenewerAddress : this.getDefaultNetworkAddresses(network).partnerRenewerAddress 
+      this.networkAddresses.partnerRenewerAddress = networkAddresses?.partnerRenewerAddress ? networkAddresses.partnerRenewerAddress : this.getDefaultNetworkAddresses(network).partnerRenewerAddress
       this.networkAddresses.rifTokenAddress = networkAddresses?.rifTokenAddress ? networkAddresses.rifTokenAddress : this.getDefaultNetworkAddresses(network).rifTokenAddress
       this.networkAddresses.partnerAddress = networkAddresses?.partnerAddress ? networkAddresses.partnerAddress : this.getDefaultNetworkAddresses(network).partnerAddress
-
     }
-
 
     this.rskOwner = new Contract(this.networkAddresses.rskOwnerAddress as string, rskOwnerInterface, this.signer)
     this.partnerRegistrar = new Contract(this.networkAddresses.partnerRegistrarAddress as string, partnerRegistrarInterface, this.signer)
     this.partnerRenewer = new Contract(this.networkAddresses.partnerRenewerAddress as string, partnerRenewerInterface, this.signer)
     this.rifToken = new Contract(this.networkAddresses.rifTokenAddress as string, erc677Interface, this.signer)
     this.partnerAddress = this.networkAddresses.partnerAddress as string
-    
   }
 
-  private getDefaultNetworkAddresses(network: Network) {
+  private getDefaultNetworkAddresses (network: Network) {
     switch (network) {
       case 'mainnet':
-        return mainnetAddresses;
-    
+        return mainnetAddresses
+
       default:
-        return testnetAddresses;
+        return testnetAddresses
     }
   }
 
@@ -151,7 +143,6 @@ export class PartnerRegistrar {
   private transferOp (label: string, to: string): OperationResult<string> {
     label = validateAndNormalizeLabel(label)
     const signerAddress = this.signer.getAddress()
-  
 
     return {
       execute: async () => {

--- a/src/PartnerRegistrar.ts
+++ b/src/PartnerRegistrar.ts
@@ -66,20 +66,25 @@ export class PartnerRegistrar {
   partnerRenewer: Contract
   rifToken: Contract
   signer: Signer
+  partnerAddress: string
+
+  // TODO: Replace placeholder address with the correct partner address
+  private readonly _defaultPartnerAddress: string = '0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc';
 
   constructor (
-    private readonly partnerAddress: string,
     partnerRegistrarAddress: string,
     partnerRenewerAddress: string,
     rskOwnerAddress: string,
     rifTokenAddress: string,
-    signer: Signer
+    signer: Signer,
+    partnerAddress?: string
   ) {
     this.rskOwner = new Contract(rskOwnerAddress, rskOwnerInterface, signer)
     this.partnerRegistrar = new Contract(partnerRegistrarAddress, partnerRegistrarInterface, signer)
     this.partnerRenewer = new Contract(partnerRenewerAddress, partnerRenewerInterface, signer)
     this.rifToken = new Contract(rifTokenAddress, erc677Interface, signer)
     this.signer = signer
+    this.partnerAddress = partnerAddress ?? this._defaultPartnerAddress
   }
 
   /**

--- a/src/PartnerRegistrar.ts
+++ b/src/PartnerRegistrar.ts
@@ -59,11 +59,11 @@ export const mainnetAddresses: NetworkAddresses = {
 }
 
 export const testnetAddresses: NetworkAddresses = {
-  partnerAddress: '',
-  partnerRegistrarAddress: '',
-  partnerRenewerAddress: '',
-  rifTokenAddress: '0x19f64674D8a5b4e652319F5e239EFd3bc969a1FE',
-  rskOwnerAddress: ''
+  partnerAddress: '0xcd32d5b7c2e1790029d3106d9f8347f42a3dfd60',
+  partnerRegistrarAddress: '0x191c582229e574f59bfa30002ed43f7f9145a9b2',
+  partnerRenewerAddress: '0x5ac6eb1be30710255b45fbdca696fa956ef12116',
+  rifTokenAddress: '0x19f64674d8a5b4e652319f5e239efd3bc969a1fe',
+  rskOwnerAddress: '0xca0a477e19bac7e0e172ccfd2e3c28a7200bdb71'
 }
 
 type CommitFunction = (label: string, owner: string, duration: BigNumber, addr?: string)=> OperationResult<{ secret: string; hash: string }>

--- a/test/addrResolver.test.ts
+++ b/test/addrResolver.test.ts
@@ -15,7 +15,7 @@ describe('addr resolver', () => {
     await tx.wait()
 
     expect(await addrResolverContract.addr(hashDomain(TEST_TARINGA_SUBDOMAIN))).toEqual(TEST_ADDRESS)
-  })
+  }, 30000)
 
   test('addr for taringa.rsk', async () => {
     const { taringaOwner, rnsRegistryContract, addrResolverContract, registerSubdomain } = await deployRNS()
@@ -27,7 +27,7 @@ describe('addr resolver', () => {
     const addressResolved = await addrResolver.addr(TEST_TARINGA_SUBDOMAIN)
 
     expect(addressResolved).toEqual(TEST_ADDRESS)
-  }, 3000)
+  }, 30000)
 
   test('resolve addr for taringa.rsk with node address', async () => {
     const { rnsRegistryContract, addrResolverContract, registerSubdomain } = await deployRNS()
@@ -39,5 +39,5 @@ describe('addr resolver', () => {
     const addressResolved = await addrResolver.addr(TEST_TARINGA_SUBDOMAIN)
 
     expect(addressResolved).toEqual(TEST_ADDRESS)
-  }, 3000)
+  }, 30000)
 })

--- a/test/rskPartnerRegistrar.test.ts
+++ b/test/rskPartnerRegistrar.test.ts
@@ -59,7 +59,7 @@ describe('partner registrar', () => {
       expect(() => {
         new PartnerRegistrar(owner, 'localhost')
       }).toThrow('Network addresses must be provided for localhost network')
-    })
+    }, 300000)
   })
 
   test('price', async () => {

--- a/test/rskPartnerRegistrar.test.ts
+++ b/test/rskPartnerRegistrar.test.ts
@@ -50,7 +50,7 @@ describe('partner registrar', () => {
       expect(partnerRegistrar.partnerRenewer.address).toEqual(partnerRenewerContract.address)
     }, 30000)
 
-    test('Should throw an error when the network is localhost but no network addresses are parsed', async () => {
+    test('Should throw an error when the network is localhost but no network addresses are passed', async () => {
       const {
         rnsOwner: owner
       } = await deployPartnerRegistrar()

--- a/test/rskPartnerRegistrar.test.ts
+++ b/test/rskPartnerRegistrar.test.ts
@@ -10,6 +10,7 @@ import {
 } from './util'
 import { BigNumber, Contract, providers, Signer } from 'ethers'
 import { generateSecret } from '../src/random'
+import { testnetAddresses } from '../src/PartnerRegistrar'
 
 function commitAndRegister (partnerRegistrar: PartnerRegistrar, name: string, rnsOwnerAddress: string) {
   const commitAndRegistrarPromise = partnerRegistrar.commitAndRegister(name, rnsOwnerAddress, BigNumber.from(2), toWei('4'), rnsOwnerAddress)
@@ -50,110 +51,140 @@ describe('partner registrar', () => {
       expect(partnerRegistrar.partnerRenewer.address).toEqual(partnerRenewerContract.address)
     }, 30000)
 
-    test('Should throw an error when the network is localhost but no network addresses are passed', async () => {
-      const {
-        rnsOwner: owner
-      } = await deployPartnerRegistrar()
+    describe('localhost', () => {
+      test('Should throw an error when the network is localhost but no network addresses are passed', async () => {
+        const {
+          rnsOwner: owner
+        } = await deployPartnerRegistrar()
 
-      expect(() => {
-        /* eslint-disable no-new */
-        new PartnerRegistrar(owner, 'localhost')
-      }).toThrow('Network addresses must be provided for localhost network')
-    }, 30000)
+        expect(() => {
+          /* eslint-disable no-new */
+          new PartnerRegistrar(owner, 'localhost')
+        }).toThrow('Network addresses must be provided for localhost network')
+      }, 30000)
 
-    test('Should throw an error when network is localhost and a partner address is not provided', async () => {
-      const {
-        rnsOwner: owner,
-        partnerRegistrarContract: dummyContract
-      } = await deployPartnerRegistrar()
+      test('Should throw an error when network is localhost and a partner address is not provided', async () => {
+        const {
+          rnsOwner: owner,
+          partnerRegistrarContract: dummyContract
+        } = await deployPartnerRegistrar()
 
-      const networkAddresses = {
-        partnerRegistrarAddress: dummyContract.address,
-        partnerRenewerAddress: dummyContract.address,
-        rskOwnerAddress: dummyContract.address,
-        rifTokenAddress: dummyContract.address
-      }
+        const networkAddresses = {
+          partnerRegistrarAddress: dummyContract.address,
+          partnerRenewerAddress: dummyContract.address,
+          rskOwnerAddress: dummyContract.address,
+          rifTokenAddress: dummyContract.address
+        }
 
-      expect(() => {
-        /* eslint-disable no-new */
-        new PartnerRegistrar(owner, 'localhost', networkAddresses)
-      }).toThrow('partnerAddress address must be provided for localhost network & it\'s value cannot be null')
-    }, 30000)
+        expect(() => {
+          /* eslint-disable no-new */
+          new PartnerRegistrar(owner, 'localhost', networkAddresses)
+        }).toThrow('partnerAddress address must be provided for localhost network & it\'s value cannot be null')
+      }, 30000)
 
-    test('Should throw an error when network is localhost and a partnerRegistrarAddress is not provided', async () => {
-      const {
-        rnsOwner: owner,
-        partnerRegistrarContract: dummyContract
-      } = await deployPartnerRegistrar()
+      test('Should throw an error when network is localhost and a partnerRegistrarAddress is not provided', async () => {
+        const {
+          rnsOwner: owner,
+          partnerRegistrarContract: dummyContract
+        } = await deployPartnerRegistrar()
 
-      const networkAddresses = {
-        partnerAddress: dummyContract.address,
-        partnerRenewerAddress: dummyContract.address,
-        rskOwnerAddress: dummyContract.address,
-        rifTokenAddress: dummyContract.address
-      }
+        const networkAddresses = {
+          partnerAddress: dummyContract.address,
+          partnerRenewerAddress: dummyContract.address,
+          rskOwnerAddress: dummyContract.address,
+          rifTokenAddress: dummyContract.address
+        }
 
-      expect(() => {
-        const testRegistrar = new PartnerRegistrar(owner, 'localhost', networkAddresses)
-      }).toThrow('partnerRegistrarAddress address must be provided for localhost network & it\'s value cannot be null')
-    }, 30000)
+        expect(() => {
+          const testRegistrar = new PartnerRegistrar(owner, 'localhost', networkAddresses)
+        }).toThrow('partnerRegistrarAddress address must be provided for localhost network & it\'s value cannot be null')
+      }, 30000)
 
-    test('Should throw an error when network is localhost and a partnerRenewerAddress is not provided', async () => {
-      const {
-        rnsOwner: owner,
-        partnerRegistrarContract: dummyContract
-      } = await deployPartnerRegistrar()
+      test('Should throw an error when network is localhost and a partnerRenewerAddress is not provided', async () => {
+        const {
+          rnsOwner: owner,
+          partnerRegistrarContract: dummyContract
+        } = await deployPartnerRegistrar()
 
-      const networkAddresses = {
-        partnerAddress: dummyContract.address,
-        partnerRegistrarAddress: dummyContract.address,
-        rskOwnerAddress: dummyContract.address,
-        rifTokenAddress: dummyContract.address
-      }
+        const networkAddresses = {
+          partnerAddress: dummyContract.address,
+          partnerRegistrarAddress: dummyContract.address,
+          rskOwnerAddress: dummyContract.address,
+          rifTokenAddress: dummyContract.address
+        }
 
-      expect(() => {
-        /* eslint-disable no-new */
-        new PartnerRegistrar(owner, 'localhost', networkAddresses)
-      }).toThrow('partnerRenewerAddress address must be provided for localhost network & it\'s value cannot be null')
-    }, 30000)
+        expect(() => {
+          /* eslint-disable no-new */
+          new PartnerRegistrar(owner, 'localhost', networkAddresses)
+        }).toThrow('partnerRenewerAddress address must be provided for localhost network & it\'s value cannot be null')
+      }, 30000)
 
-    test('Should throw an error when network is localhost and a rifTokenAddress is not provided', async () => {
-      const {
-        rnsOwner: owner,
-        partnerRegistrarContract: dummyContract
-      } = await deployPartnerRegistrar()
+      test('Should throw an error when network is localhost and a rifTokenAddress is not provided', async () => {
+        const {
+          rnsOwner: owner,
+          partnerRegistrarContract: dummyContract
+        } = await deployPartnerRegistrar()
 
-      const networkAddresses = {
-        partnerAddress: dummyContract.address,
-        partnerRegistrarAddress: dummyContract.address,
-        partnerRenewerAddress: dummyContract.address,
-        rskOwnerAddress: dummyContract.address
-      }
+        const networkAddresses = {
+          partnerAddress: dummyContract.address,
+          partnerRegistrarAddress: dummyContract.address,
+          partnerRenewerAddress: dummyContract.address,
+          rskOwnerAddress: dummyContract.address
+        }
 
-      expect(() => {
-        /* eslint-disable no-new */
-        new PartnerRegistrar(owner, 'localhost', networkAddresses)
-      }).toThrow('rifTokenAddress address must be provided for localhost network & it\'s value cannot be null')
-    }, 30000)
+        expect(() => {
+          /* eslint-disable no-new */
+          new PartnerRegistrar(owner, 'localhost', networkAddresses)
+        }).toThrow('rifTokenAddress address must be provided for localhost network & it\'s value cannot be null')
+      }, 30000)
 
-    test('Should throw an error when network is localhost and a rskOwnerAddress is not provided', async () => {
-      const {
-        rnsOwner: owner,
-        partnerRegistrarContract: dummyContract
-      } = await deployPartnerRegistrar()
+      test('Should throw an error when network is localhost and a rskOwnerAddress is not provided', async () => {
+        const {
+          rnsOwner: owner,
+          partnerRegistrarContract: dummyContract
+        } = await deployPartnerRegistrar()
 
-      const networkAddresses = {
-        partnerAddress: dummyContract.address,
-        partnerRegistrarAddress: dummyContract.address,
-        partnerRenewerAddress: dummyContract.address,
-        rifTokenAddress: dummyContract.address
-      }
+        const networkAddresses = {
+          partnerAddress: dummyContract.address,
+          partnerRegistrarAddress: dummyContract.address,
+          partnerRenewerAddress: dummyContract.address,
+          rifTokenAddress: dummyContract.address
+        }
 
-      expect(() => {
-        /* eslint-disable no-new */
-        new PartnerRegistrar(owner, 'localhost', networkAddresses)
-      }).toThrow('rskOwnerAddress address must be provided for localhost network & it\'s value cannot be null')
-    }, 30000)
+        expect(() => {
+          /* eslint-disable no-new */
+          new PartnerRegistrar(owner, 'localhost', networkAddresses)
+        }).toThrow('rskOwnerAddress address must be provided for localhost network & it\'s value cannot be null')
+      }, 30000)
+    })
+    describe('testnet', () => {
+      test('Should set default testnet addresses if no network address is provided', async () => {
+        const {
+          rnsOwner: owner
+        } = await deployPartnerRegistrar()
+
+        const partnerRegistrar = new PartnerRegistrar(owner, 'testnet')
+        expect(partnerRegistrar.networkAddresses).toMatchObject(testnetAddresses)
+      }, 30000)
+
+      test('Should set default testnet addresses and override partner registrar address provided', async () => {
+        const {
+          rnsOwner: owner,
+          partnerRegistrarContract: dummyContract
+        } = await deployPartnerRegistrar()
+
+        const networkAddresses = {
+          partnerRegistrarAddress: dummyContract.address
+        }
+
+        const partnerRegistrar = new PartnerRegistrar(owner, 'testnet', networkAddresses)
+        expect(partnerRegistrar.networkAddresses.partnerAddress).toEqual(testnetAddresses.partnerAddress)
+        expect(partnerRegistrar.networkAddresses.partnerRegistrarAddress).toEqual(dummyContract.address)
+        expect(partnerRegistrar.networkAddresses.partnerRenewerAddress).toEqual(testnetAddresses.partnerRenewerAddress)
+        expect(partnerRegistrar.networkAddresses.rifTokenAddress).toEqual(testnetAddresses.rifTokenAddress)
+        expect(partnerRegistrar.networkAddresses.rskOwnerAddress).toEqual(testnetAddresses.rskOwnerAddress)
+      }, 30000)
+    })
   })
 
   test('price', async () => {

--- a/test/rskPartnerRegistrar.test.ts
+++ b/test/rskPartnerRegistrar.test.ts
@@ -20,27 +20,47 @@ function commitAndRegister (partnerRegistrar: PartnerRegistrar, name: string, rn
 }
 
 function getPartnerRegistrar (partnerRegistrarContract: Contract, partnerRenewerContract: Contract, rskOwnerContract: Contract, rifTokenContract: Contract, owner: Signer, partnerAccountAddress?: string): PartnerRegistrar {
-  return new PartnerRegistrar(partnerRegistrarContract.address, partnerRenewerContract.address, rskOwnerContract.address, rifTokenContract.address, owner, partnerAccountAddress)
+  const networkAddresses = {
+    rskOwnerAddress: rskOwnerContract.address,
+    rifTokenAddress: rifTokenContract.address,
+    partnerRegistrarAddress: partnerRegistrarContract.address,
+    partnerRenewerAddress: partnerRenewerContract.address,
+    partnerAddress: partnerAccountAddress
+  }
+  return new PartnerRegistrar(owner, 'localhost', networkAddresses);
 }
 
 describe('partner registrar', () => {
-  test('constructor', async () => {
-    const {
-      partnerRegistrarContract,
-      partnerRenewerContract,
-      partnerAccountAddress,
-      rskOwnerContract,
-      rifTokenContract,
-      rnsOwner: owner
-    } = await deployPartnerRegistrar()
+  
+  describe('constructor', () => {
+    test('should successfully initialize the registrar class', async () => {
+      const {
+        partnerRegistrarContract,
+        partnerRenewerContract,
+        partnerAccountAddress,
+        rskOwnerContract,
+        rifTokenContract,
+        rnsOwner: owner
+      } = await deployPartnerRegistrar()
+  
+      const partnerRegistrar = getPartnerRegistrar(partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner, partnerAccountAddress)
+      expect(partnerRegistrar.signer).toEqual(owner)
+      expect(partnerRegistrar.rskOwner.address).toEqual(rskOwnerContract.address)
+      expect(partnerRegistrar.rifToken.address).toEqual(rifTokenContract?.address)
+      expect(partnerRegistrar.partnerRegistrar.address).toEqual(partnerRegistrarContract.address)
+      expect(partnerRegistrar.partnerRenewer.address).toEqual(partnerRenewerContract.address)
+    }, 300000)
 
-    const partnerRegistrar = getPartnerRegistrar(partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner, partnerAccountAddress)
-    expect(partnerRegistrar.signer).toEqual(owner)
-    expect(partnerRegistrar.rskOwner.address).toEqual(rskOwnerContract.address)
-    expect(partnerRegistrar.rifToken.address).toEqual(rifTokenContract?.address)
-    expect(partnerRegistrar.partnerRegistrar.address).toEqual(partnerRegistrarContract.address)
-    expect(partnerRegistrar.partnerRenewer.address).toEqual(partnerRenewerContract.address)
-  }, 300000)
+    test('Should throw an error when the network is localhost but no network addresses are parsed', async () => {
+      const {
+        rnsOwner: owner
+      } = await deployPartnerRegistrar()
+
+      expect(() => {
+        new PartnerRegistrar(owner, 'localhost')
+      }).toThrow('Network addresses must be provided for localhost network')
+    })
+  })
 
   test('price', async () => {
     const {

--- a/test/rskPartnerRegistrar.test.ts
+++ b/test/rskPartnerRegistrar.test.ts
@@ -27,11 +27,10 @@ function getPartnerRegistrar (partnerRegistrarContract: Contract, partnerRenewer
     partnerRenewerAddress: partnerRenewerContract.address,
     partnerAddress: partnerAccountAddress
   }
-  return new PartnerRegistrar(owner, 'localhost', networkAddresses);
+  return new PartnerRegistrar(owner, 'localhost', networkAddresses)
 }
 
 describe('partner registrar', () => {
-  
   describe('constructor', () => {
     test('should successfully initialize the registrar class', async () => {
       const {
@@ -42,14 +41,14 @@ describe('partner registrar', () => {
         rifTokenContract,
         rnsOwner: owner
       } = await deployPartnerRegistrar()
-  
+
       const partnerRegistrar = getPartnerRegistrar(partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner, partnerAccountAddress)
       expect(partnerRegistrar.signer).toEqual(owner)
       expect(partnerRegistrar.rskOwner.address).toEqual(rskOwnerContract.address)
       expect(partnerRegistrar.rifToken.address).toEqual(rifTokenContract?.address)
       expect(partnerRegistrar.partnerRegistrar.address).toEqual(partnerRegistrarContract.address)
       expect(partnerRegistrar.partnerRenewer.address).toEqual(partnerRenewerContract.address)
-    }, 300000)
+    }, 30000)
 
     test('Should throw an error when the network is localhost but no network addresses are parsed', async () => {
       const {
@@ -57,9 +56,104 @@ describe('partner registrar', () => {
       } = await deployPartnerRegistrar()
 
       expect(() => {
+        /* eslint-disable no-new */
         new PartnerRegistrar(owner, 'localhost')
       }).toThrow('Network addresses must be provided for localhost network')
-    }, 300000)
+    }, 30000)
+
+    test('Should throw an error when network is localhost and a partner address is not provided', async () => {
+      const {
+        rnsOwner: owner,
+        partnerRegistrarContract: dummyContract
+      } = await deployPartnerRegistrar()
+
+      const networkAddresses = {
+        partnerRegistrarAddress: dummyContract.address,
+        partnerRenewerAddress: dummyContract.address,
+        rskOwnerAddress: dummyContract.address,
+        rifTokenAddress: dummyContract.address
+      }
+
+      expect(() => {
+        /* eslint-disable no-new */
+        new PartnerRegistrar(owner, 'localhost', networkAddresses)
+      }).toThrow('partnerAddress address must be provided for localhost network & it\'s value cannot be null')
+    }, 30000)
+
+    test('Should throw an error when network is localhost and a partnerRegistrarAddress is not provided', async () => {
+      const {
+        rnsOwner: owner,
+        partnerRegistrarContract: dummyContract
+      } = await deployPartnerRegistrar()
+
+      const networkAddresses = {
+        partnerAddress: dummyContract.address,
+        partnerRenewerAddress: dummyContract.address,
+        rskOwnerAddress: dummyContract.address,
+        rifTokenAddress: dummyContract.address
+      }
+
+      expect(() => {
+        const testRegistrar = new PartnerRegistrar(owner, 'localhost', networkAddresses)
+      }).toThrow('partnerRegistrarAddress address must be provided for localhost network & it\'s value cannot be null')
+    }, 30000)
+
+    test('Should throw an error when network is localhost and a partnerRenewerAddress is not provided', async () => {
+      const {
+        rnsOwner: owner,
+        partnerRegistrarContract: dummyContract
+      } = await deployPartnerRegistrar()
+
+      const networkAddresses = {
+        partnerAddress: dummyContract.address,
+        partnerRegistrarAddress: dummyContract.address,
+        rskOwnerAddress: dummyContract.address,
+        rifTokenAddress: dummyContract.address
+      }
+
+      expect(() => {
+        /* eslint-disable no-new */
+        new PartnerRegistrar(owner, 'localhost', networkAddresses)
+      }).toThrow('partnerRenewerAddress address must be provided for localhost network & it\'s value cannot be null')
+    }, 30000)
+
+    test('Should throw an error when network is localhost and a rifTokenAddress is not provided', async () => {
+      const {
+        rnsOwner: owner,
+        partnerRegistrarContract: dummyContract
+      } = await deployPartnerRegistrar()
+
+      const networkAddresses = {
+        partnerAddress: dummyContract.address,
+        partnerRegistrarAddress: dummyContract.address,
+        partnerRenewerAddress: dummyContract.address,
+        rskOwnerAddress: dummyContract.address
+      }
+
+      expect(() => {
+        /* eslint-disable no-new */
+        new PartnerRegistrar(owner, 'localhost', networkAddresses)
+      }).toThrow('rifTokenAddress address must be provided for localhost network & it\'s value cannot be null')
+    }, 30000)
+
+    test('Should throw an error when network is localhost and a rskOwnerAddress is not provided', async () => {
+      const {
+        rnsOwner: owner,
+        partnerRegistrarContract: dummyContract
+      } = await deployPartnerRegistrar()
+
+      const networkAddresses = {
+        partnerAddress: dummyContract.address,
+        partnerRegistrarAddress: dummyContract.address,
+        partnerRenewerAddress: dummyContract.address,
+        rifTokenAddress: dummyContract.address
+      }
+
+      expect(() => {
+        /* eslint-disable no-new */
+        new PartnerRegistrar(owner, 'localhost', networkAddresses)
+      }).toThrow('rskOwnerAddress address must be provided for localhost network & it\'s value cannot be null')
+    }, 30000)
   })
 
   test('price', async () => {
@@ -511,7 +605,7 @@ describe('partner registrar', () => {
 
       const tx = mainTx.toNumber()
       expect(tx).toBeGreaterThan(0)
-    })
+    }, 300000)
 
     test('should estimate gas for register', async () => {
       const {
@@ -698,7 +792,7 @@ describe('partner registrar', () => {
         rskOwnerContract,
         rifTokenContract,
         alice,
-        partnerAddress,
+        partnerAddress
       )
       const sovrynPartnerRegistrar = getPartnerRegistrar(
         sovrynPartnerRegistrarContract,
@@ -706,7 +800,7 @@ describe('partner registrar', () => {
         sovrynOwnerContract,
         rifTokenContract,
         bob,
-        partnerAddress,
+        partnerAddress
       )
 
       // Calculating the price to register 'cheta.rsk' and 'cheta.sovryn'

--- a/test/rskPartnerRegistrar.test.ts
+++ b/test/rskPartnerRegistrar.test.ts
@@ -19,8 +19,8 @@ function commitAndRegister (partnerRegistrar: PartnerRegistrar, name: string, rn
   return commitAndRegistrarPromise
 }
 
-function getPartnerRegistrar (partnerAccountAddress: string, partnerRegistrarContract: Contract, partnerRenewerContract: Contract, rskOwnerContract: Contract, rifTokenContract: Contract, owner: Signer): PartnerRegistrar {
-  return new PartnerRegistrar(partnerAccountAddress, partnerRegistrarContract.address, partnerRenewerContract.address, rskOwnerContract.address, rifTokenContract.address, owner)
+function getPartnerRegistrar (partnerRegistrarContract: Contract, partnerRenewerContract: Contract, rskOwnerContract: Contract, rifTokenContract: Contract, owner: Signer, partnerAccountAddress?: string): PartnerRegistrar {
+  return new PartnerRegistrar(partnerRegistrarContract.address, partnerRenewerContract.address, rskOwnerContract.address, rifTokenContract.address, owner, partnerAccountAddress)
 }
 
 describe('partner registrar', () => {
@@ -34,7 +34,7 @@ describe('partner registrar', () => {
       rnsOwner: owner
     } = await deployPartnerRegistrar()
 
-    const partnerRegistrar = getPartnerRegistrar(partnerAccountAddress, partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner)
+    const partnerRegistrar = getPartnerRegistrar(partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner, partnerAccountAddress)
     expect(partnerRegistrar.signer).toEqual(owner)
     expect(partnerRegistrar.rskOwner.address).toEqual(rskOwnerContract.address)
     expect(partnerRegistrar.rifToken.address).toEqual(rifTokenContract?.address)
@@ -51,7 +51,7 @@ describe('partner registrar', () => {
       rifTokenContract,
       rnsOwner: owner
     } = await deployPartnerRegistrar()
-    const partnerRegistrar = getPartnerRegistrar(partnerAccountAddress, partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner)
+    const partnerRegistrar = getPartnerRegistrar(partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner, partnerAccountAddress)
 
     const duration = BigNumber.from(2)
     const name = 'cheta'
@@ -67,7 +67,7 @@ describe('partner registrar', () => {
       rifTokenContract,
       rnsOwner: owner
     } = await deployPartnerRegistrar()
-    const partnerRegistrar = getPartnerRegistrar(partnerAccountAddress, partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner)
+    const partnerRegistrar = getPartnerRegistrar(partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner, partnerAccountAddress)
 
     const name = 'cheta'
     expect((await partnerRegistrar.available(name))).toBe(true)
@@ -85,7 +85,7 @@ describe('partner registrar', () => {
     } = await deployPartnerRegistrar({
       defaultMinCommitmentAge: 5
     })
-    const partnerRegistrar = getPartnerRegistrar(partnerAccountAddress, partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner)
+    const partnerRegistrar = getPartnerRegistrar(partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner, partnerAccountAddress)
 
     const name = 'cheta'
 
@@ -106,7 +106,7 @@ describe('partner registrar', () => {
     } = await deployPartnerRegistrar({
       defaultMinCommitmentAge: 5
     })
-    const partnerRegistrar = getPartnerRegistrar(partnerAccountAddress, partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner)
+    const partnerRegistrar = getPartnerRegistrar(partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner, partnerAccountAddress)
 
     const name = 'cheta'
 
@@ -136,7 +136,7 @@ describe('partner registrar', () => {
     } = await deployPartnerRegistrar({
       defaultMinCommitmentAge: 5
     })
-    let partnerRegistrar = getPartnerRegistrar(partnerAccountAddress, partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner)
+    let partnerRegistrar = getPartnerRegistrar(partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner, partnerAccountAddress)
 
     const rns = new RNS(rnsRegistryContract.address, owner)
 
@@ -154,7 +154,7 @@ describe('partner registrar', () => {
     expect((await partnerRegistrar.ownerOf(name))).toEqual(await newOwner.getAddress())
     expect((await rns.getOwner(name + '.rsk'))).toEqual(rnsOwnerAddress)
 
-    partnerRegistrar = getPartnerRegistrar(partnerAccountAddress, partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, newOwner)
+    partnerRegistrar = getPartnerRegistrar(partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, newOwner, partnerAccountAddress)
 
     const txhash = await partnerRegistrar.reclaim(name)
 
@@ -178,7 +178,7 @@ describe('partner registrar', () => {
           defaultMinCommitmentAge: 5
         }
       )
-      const partnerRegistrar = getPartnerRegistrar(partnerAccountAddress, partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner)
+      const partnerRegistrar = getPartnerRegistrar(partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner, partnerAccountAddress)
 
       const name = 'cheta'
 
@@ -204,7 +204,7 @@ describe('partner registrar', () => {
         rnsOwnerAddress,
         rnsOwner: owner
       } = await deployPartnerRegistrar()
-      const partnerRegistrar = getPartnerRegistrar(partnerAccountAddress, partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner)
+      const partnerRegistrar = getPartnerRegistrar(partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner, partnerAccountAddress)
 
       const name = 'cheta'
 
@@ -228,7 +228,7 @@ describe('partner registrar', () => {
           defaultMinCommitmentAge: 5
         }
       )
-      const partnerRegistrar = getPartnerRegistrar(partnerAccountAddress, partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner)
+      const partnerRegistrar = getPartnerRegistrar(partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner, partnerAccountAddress)
 
       const name = 'cheta'
 
@@ -257,7 +257,7 @@ describe('partner registrar', () => {
             defaultMinCommitmentAge
           }
         )
-        const partnerRegistrar = getPartnerRegistrar(partnerAccountAddress, partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner)
+        const partnerRegistrar = getPartnerRegistrar(partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner, partnerAccountAddress)
 
         const name = 'cheta'
         const duration = BigNumber.from(2)
@@ -298,7 +298,7 @@ describe('partner registrar', () => {
             defaultMinCommitmentAge
           }
         )
-        const partnerRegistrar = getPartnerRegistrar(partnerAccountAddress, partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner)
+        const partnerRegistrar = getPartnerRegistrar(partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner, partnerAccountAddress)
 
         const name = 'cheta'
         const duration = BigNumber.from(2)
@@ -334,7 +334,7 @@ describe('partner registrar', () => {
           defaultMinCommitmentAge
         }
       )
-      const partnerRegistrar = getPartnerRegistrar(partnerAccountAddress, partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner)
+      const partnerRegistrar = getPartnerRegistrar(partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner, partnerAccountAddress)
 
       const name = 'cheta'
       const duration = BigNumber.from(2)
@@ -368,7 +368,7 @@ describe('partner registrar', () => {
             defaultMinCommitmentAge
           }
         )
-        const partnerRegistrar = getPartnerRegistrar(partnerAccountAddress, partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner)
+        const partnerRegistrar = getPartnerRegistrar(partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner, partnerAccountAddress)
 
         const name = 'cheta'
         const duration = BigNumber.from(2)
@@ -400,7 +400,7 @@ describe('partner registrar', () => {
             defaultMinCommitmentAge
           }
         )
-        const partnerRegistrar = getPartnerRegistrar(partnerAccountAddress, partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner)
+        const partnerRegistrar = getPartnerRegistrar(partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner, partnerAccountAddress)
 
         const name = 'cheta'
         const duration = BigNumber.from(2)
@@ -433,7 +433,7 @@ describe('partner registrar', () => {
           defaultMinCommitmentAge: 5
         }
       )
-      const partnerRegistrar = getPartnerRegistrar(partnerAccountAddress, partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner)
+      const partnerRegistrar = getPartnerRegistrar(partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner, partnerAccountAddress)
 
       const name = 'cheta'
       await commitAndRegister(partnerRegistrar, name, rnsOwnerAddress)
@@ -457,7 +457,7 @@ describe('partner registrar', () => {
           defaultMinCommitmentAge: 1
         }
       )
-      const partnerRegistrar = getPartnerRegistrar(partnerAccountAddress, partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner)
+      const partnerRegistrar = getPartnerRegistrar(partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner, partnerAccountAddress)
 
       const name = 'cheta'
 
@@ -481,7 +481,7 @@ describe('partner registrar', () => {
           defaultMinCommitmentAge: 0
         }
       )
-      const partnerRegistrar = getPartnerRegistrar(partnerAccountAddress, partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner)
+      const partnerRegistrar = getPartnerRegistrar(partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner, partnerAccountAddress)
 
       const name = 'cheta'
 
@@ -507,7 +507,7 @@ describe('partner registrar', () => {
           defaultMinCommitmentAge: 0
         }
       )
-      const partnerRegistrar = getPartnerRegistrar(partnerAccountAddress, partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner)
+      const partnerRegistrar = getPartnerRegistrar(partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner, partnerAccountAddress)
 
       const name = 'cheta'
 
@@ -533,7 +533,7 @@ describe('partner registrar', () => {
           defaultMinCommitmentAge: 1
         }
       )
-      const partnerRegistrar = getPartnerRegistrar(partnerAccountAddress, partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner)
+      const partnerRegistrar = getPartnerRegistrar(partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner, partnerAccountAddress)
 
       const name = 'cheta'
 
@@ -557,7 +557,7 @@ describe('partner registrar', () => {
           defaultMinCommitmentAge: 0
         }
       )
-      const partnerRegistrar = getPartnerRegistrar(partnerAccountAddress, partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner)
+      const partnerRegistrar = getPartnerRegistrar(partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner, partnerAccountAddress)
 
       const name = 'cheta'
 
@@ -581,7 +581,7 @@ describe('partner registrar', () => {
         defaultMinCommitmentAge: 5
       })
 
-      const partnerRegistrar = getPartnerRegistrar(partnerAccountAddress, partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner)
+      const partnerRegistrar = getPartnerRegistrar(partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner, partnerAccountAddress)
 
       const name = 'cheta'
 
@@ -609,7 +609,7 @@ describe('partner registrar', () => {
         defaultMinCommitmentAge: 5
       })
 
-      const partnerRegistrar = getPartnerRegistrar(partnerAccountAddress, partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner)
+      const partnerRegistrar = getPartnerRegistrar(partnerRegistrarContract, partnerRenewerContract, rskOwnerContract, rifTokenContract, owner, partnerAccountAddress)
       expect(() => {
         // @ts-expect-error: the argument 'invalidOperation' is not a valid accepted operation name, however
         // the function needs to be tested that it correctly throws an error when it is invoked with an
@@ -673,20 +673,20 @@ describe('partner registrar', () => {
 
       // Creating sdk Partner Registrar instances
       const rskPartnerRegistrar = getPartnerRegistrar(
-        partnerAddress,
         rskPartnerRegistrarContract,
         rskPartnerRenewerContract,
         rskOwnerContract,
         rifTokenContract,
-        alice
+        alice,
+        partnerAddress,
       )
       const sovrynPartnerRegistrar = getPartnerRegistrar(
-        partnerAddress,
         sovrynPartnerRegistrarContract,
         sovrynPartnerRenewerContract,
         sovrynOwnerContract,
         rifTokenContract,
-        bob
+        bob,
+        partnerAddress,
       )
 
       // Calculating the price to register 'cheta.rsk' and 'cheta.sovryn'


### PR DESCRIPTION
This PR  introduces an enhancement that makes the network addresses for initialising the PartnerRegistrar class on the sdk optional for  mainnet and testnet